### PR TITLE
Strip index signature keys

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,16 +7,22 @@ interface SafeProxy<Initial, To> {
   $pmap: (f: (t: To) => Promise<To>) => Promise<Initial>;
 }
 
+type RemoveIndex<T> = {
+  [K in keyof T as string extends K ? never : K]: T[K];
+};
+
 type UnionToIntersection<U> = ((U extends any ? (k: U) => void : never) extends (k: infer I) => void
   ? { [K in Exclude<keyof I, keyof U>]: I[K] }
   : never) &
   U;
 
-export type U<T> = {
+type U<T> = {
   [K in keyof UnionToIntersection<T>]-?: NonNullable<UnionToIntersection<T>[K]>;
 };
 
-type Safe<Initial, To> = SafeProxy<Initial, To> & { [K in keyof U<To>]: Safe<Initial, U<To>[K]> };
+type V<T> = U<RemoveIndex<T>>;
+
+type Safe<Initial, To> = SafeProxy<Initial, To> & { [K in keyof V<To>]: Safe<Initial, V<To>[K]> };
 
 interface Proxied {
   value: any;

--- a/test/safe.spec.ts
+++ b/test/safe.spec.ts
@@ -157,9 +157,6 @@ describe('safe', () => {
 
 type UnionType = { b: string } | { a: number };
 
-type UnionTypeWithIndex = { b: string } | { a: number; [key: string]: unknown };
-type UnionTypeWithIndexToNumber = { b: string } | { a: number; [key: string]: number };
-
 type NestedUnion = { a: { x: number } } | { b: { x: string } };
 
 type SharingUnion = { a: string } | { a: number };
@@ -183,24 +180,6 @@ describe('union type traversal', () => {
     it('rejects incorrect type', () => {
       // @ts-expect-error
       const num: string | undefined = safe<ArrayType>(value).a[0].x.$;
-      expect(num).toBeFalsy();
-    });
-  });
-
-  describe('indexed keys', () => {
-    it('prefers named prop types', () => {
-      const num: unknown | undefined = safe<UnionTypeWithIndex>(value).a.$;
-      expect(num).toBeFalsy();
-    });
-
-    it('allows indexed fields', () => {
-      const num: number | undefined = safe<UnionTypeWithIndexToNumber>(value).z.$;
-      expect(num).toBeFalsy();
-    });
-
-    it('join both sides of union', () => {
-      // @ts-expect-error
-      const num: number | undefined = safe<UnionTypeWithIndexToNumber>(value).b.$;
       expect(num).toBeFalsy();
     });
   });


### PR DESCRIPTION
Because of changes in TypeScript's type intersection, having index signatures makes the children's type to turn into `unknown` when one of the unions has them.

In older versions of TS `string & number` was fine and was essentially the same thing as `string | number`. In more recent versions that resulted in the correct type of `never`. That causes safe's type inference to get confused and turn everything into `unknown`. By stripping the indexed signature from the type we can get around this issue, with the trade-off of getting type errors when trying to access properties that haven't been explicitly declared in the type being proxied by `safe-navigation`.

The example below gives an error on `d` unless you comment out the indexed property from `SecondType` using the current version of `safe-navigation`. With this PR the error is not there.
```ts
class FirstType {
  a: string;
  b: string;
}

class SecondType {
  c: { d: string };
  [key: string]: unknown;
}

type Union = FirstType | SecondType;

safe({} as Union).c.d.$;
```
